### PR TITLE
check TARGET_DEVICE pls -- breaks my builds

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -22,4 +22,7 @@
 
 LOCAL_PATH := $(call my-dir)
 
-include $(call all-makefiles-under,$(LOCAL_PATH))
+ifeq ($(TARGET_DEVICE),otter)
+    include $(call all-makefiles-under,$(LOCAL_PATH))
+endif
+


### PR DESCRIPTION
I get several conflicts when building other devices under the AOKP repo, if this device doesn't have a TARGET_DEVICE check.  Thanks.
